### PR TITLE
Performance improvements in Util.lua

### DIFF
--- a/src/components/Util.lua
+++ b/src/components/Util.lua
@@ -4,8 +4,13 @@
 --- File created at [24/05/2021 09:57]
 ---
 
-function math.round(num, numDecimalPlaces)
-    return tonumber(string.format("%." .. (numDecimalPlaces or 0) .. "f", num))
+function math.round(value, numDecimalPlaces)
+	if numDecimalPlaces then
+		local power = 10^numDecimalPlaces
+		return math.floor((value * power) + 0.5) / (power)
+	else
+		return math.floor(value + 0.5)
+	end
 end
 
 function string.starts(String, Start)


### PR DESCRIPTION
Here the performance test

```lua
function math.Timer()
    local timer = os.clock()
    return function()
        return (os.clock() - timer)
    end
end

local round1 = function(value, numDecimalPlaces)
	if numDecimalPlaces then
		local power = 10^numDecimalPlaces
		return math.floor((value * power) + 0.5) / (power)
	else
		return math.floor(value + 0.5)
	end
end

local round2 = function(num, numDecimalPlaces)
    return tonumber(string.format("%." .. (numDecimalPlaces or 0) .. "f", num))
end

local timer1 = math.Timer()
for i = 1, 1000000 do
     round1(1883.948364, 2)
end
print(timer1()) -- 0.077

local timer2 = math.Timer()
for i = 1, 1000000 do
     round2(1883.948364, 2)
end
print(timer2()) -- 1.176
```